### PR TITLE
Fixed issue with path to styles.scss when running tests

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -66,7 +66,7 @@
             "tsConfig": "src/tsconfig.spec.json",
             "karmaConfig": "src/karma.conf.js",
             "styles": [
-              "styles.css"
+              "src/styles.css"
             ],
             "scripts": [],
             "assets": [


### PR DESCRIPTION
The `angular.json` file has an incorrect path to the `styles.scss` file in the test step.
I've updated it to add the `src/` as is required.

This was the error I got when trying to run the tests with `npm test`:
```
ERROR in multi ./styles.css
Module not found: Error: Can't resolve '/Users/ns/dev/ngx-example/styles.css' in '/Users/ns/dev/ngx-example'
 @ multi ./styles.css styles[0]
```